### PR TITLE
(fix) make emergency support email addresses consistent

### DIFF
--- a/agreements/service_level_agreement.md
+++ b/agreements/service_level_agreement.md
@@ -58,7 +58,7 @@
     2. Urgent tickets must receive a first reply within 1 hour (standard) or 30
        minutes (enhanced), at any time of the day or night.
 
-    3. Tickets created by emailing emergency-support@dxw.com are automatically
+    3. Tickets created by emailing support-emergency@dxw.com are automatically
        marked as urgent.
 
 4. ### High priority tickets


### PR DESCRIPTION
Lee informed me that `support-emergency@dxw.com` is the canonical one that should be used, though both work.